### PR TITLE
sched/features: Disable fair gentle sleepers

### DIFF
--- a/kernel/sched/features.h
+++ b/kernel/sched/features.h
@@ -3,7 +3,7 @@
  * them to run sooner, but does not allow tons of sleepers to
  * rip the spread apart.
  */
-SCHED_FEAT(GENTLE_FAIR_SLEEPERS, true)
+SCHED_FEAT(GENTLE_FAIR_SLEEPERS, false)
 
 /*
  * Place new tasks ahead so that they do not starve already running


### PR DESCRIPTION
Most msm8994 devices show signs of slowing after time.
Improve UX responsiveness by disabling gentle fair sleepers.